### PR TITLE
-Dialog asking if the user wants to add a material with the same name

### DIFF
--- a/app/src/main/java/com/example/friendly_words/data/daos/ConfigurationDao.kt
+++ b/app/src/main/java/com/example/friendly_words/data/daos/ConfigurationDao.kt
@@ -18,7 +18,8 @@ interface ConfigurationDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(configuration: Configuration): Long
-
+    @Query("SELECT * FROM configurations")
+    suspend fun getAllOnce(): List<Configuration>
     @Delete
     suspend fun delete(configuration: Configuration)
 

--- a/app/src/main/java/com/example/friendly_words/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/friendly_words/data/database/AppDatabase.kt
@@ -23,7 +23,7 @@ import com.example.friendly_words.data.entities.ConfigurationResource
         ConfigurationImageUsage::class
         // todo dodanie reszty encji jak juz dao beda zrobione
     ],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/friendly_words/data/repositories/ConfigurationRepository.kt
+++ b/app/src/main/java/com/example/friendly_words/data/repositories/ConfigurationRepository.kt
@@ -15,6 +15,7 @@ class ConfigurationRepository @Inject constructor(
 
     // metody dla konfiguracji
     fun getAll(): Flow<List<Configuration>> = dao.getAll()
+    suspend fun getAllOnce(): List<Configuration> = dao.getAllOnce()
 
     suspend fun getById(id: Long): Configuration = dao.getById(id)
 

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialEvent.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialEvent.kt
@@ -6,7 +6,7 @@ sealed class ConfigurationMaterialEvent {
     data class ConfirmDelete(val index: Int) : ConfigurationMaterialEvent()
     data class ImageSelectionChanged(val selected: List<Boolean>) : ConfigurationMaterialEvent()
     data class LearningTestChanged(val index: Int, val inLearning: Boolean, val inTest: Boolean) : ConfigurationMaterialEvent()
-    data class AddWord(val word: String) : ConfigurationMaterialEvent()
+    data class AddWord(val id: Long) : ConfigurationMaterialEvent()
     object ShowAddDialog : ConfigurationMaterialEvent()
     object HideAddDialog : ConfigurationMaterialEvent()
     object CancelDelete : ConfigurationMaterialEvent()

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialScreen.kt
@@ -28,12 +28,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.rememberAsyncImagePainter
 import com.example.friendly_words.R
 import com.example.friendly_words.therapist.ui.components.YesNoDialog
+import com.example.friendly_words.therapist.ui.components.YesNoDialogWithName
 import com.example.friendly_words.therapist.ui.theme.DarkBlue
 import com.example.friendly_words.therapist.ui.theme.LightBlue
 import com.example.friendly_words.therapist.ui.theme.White
 
 data class VocabularyItem(
+    val id:Long,
     val word: String,
+    val learnedWord:String,
     val selectedImages: List<Boolean>,
     val inLearningStates: List<Boolean>,
     val inTestStates: List<Boolean>,
@@ -228,7 +231,7 @@ fun ConfigurationMaterialScreen(
                             ) {
                                 Box(modifier = Modifier.weight(1f)) {
                                     Text(
-                                        item.word,
+                                        item.learnedWord,
                                         fontSize = 30.sp,
                                         fontWeight = FontWeight.Bold,
                                     )
@@ -292,9 +295,10 @@ fun ConfigurationMaterialScreen(
 
                     // Dialog przeniesiony poza pętlę LazyColumn
                     if (state.showDeleteDialog && state.wordIndexToDelete != null && state.wordIndexToDelete!! in state.vocabItems.indices) {
-                        YesNoDialog(
+                        YesNoDialogWithName(
                             show = true,
-                            message = "Czy chcesz usunąć z konfiguracji materiał:\n${state.vocabItems[state.wordIndexToDelete!!].word}?",
+                            message = "Czy chcesz usunąć z kroku uczenia słowo:",
+                            name="${state.vocabItems[state.wordIndexToDelete!!].learnedWord}?",
                             onConfirm = {
                                 viewModel.onEvent(ConfigurationMaterialEvent.ConfirmDelete(state.wordIndexToDelete!!))
                             },
@@ -361,7 +365,7 @@ fun ConfigurationMaterialScreen(
             AlertDialog(
                 onDismissRequest = { viewModel.onEvent(ConfigurationMaterialEvent.HideAddDialog) },
                 title = {
-                    Text(text="Wybierz materiał, które chcesz dodać do konfiguracji:", fontSize = 26.sp,
+                    Text(text="Wybierz materiał, które chcesz dodać do kroku uczenia:", fontSize = 26.sp,
                     fontStyle = FontStyle.Italic)
 
                 },
@@ -370,13 +374,13 @@ fun ConfigurationMaterialScreen(
                         Text("BRAK, DODAJ W MATERIAŁACH")
                     } else {
                         Column {
-                            state.availableWordsToAdd.forEach { word ->
+                            state.availableWordsToAdd.forEach { resource ->
                                 Text(
-                                    text = word,
+                                    text = resource.name,
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .clickable {
-                                            viewModel.onEvent(ConfigurationMaterialEvent.AddWord(word))
+                                            viewModel.onEvent(ConfigurationMaterialEvent.AddWord(resource.id))
                                         }
                                         .padding(vertical = 8.dp),
                                     fontSize = 18.sp

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialState.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialState.kt
@@ -1,8 +1,10 @@
 package com.example.friendly_words.therapist.ui.configuration.material
 
+import com.example.friendly_words.data.entities.Resource
+
 data class ConfigurationMaterialState(
     val vocabItems: List<VocabularyItem> = emptyList(),
-    val availableWordsToAdd: List<String> = emptyList(),
+    val availableWordsToAdd: List<Resource> = emptyList(),
     val selectedWordIndex: Int = 0,
     val wordIndexToDelete: Int? = null,
     val showDeleteDialog: Boolean = false,

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveEvent.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveEvent.kt
@@ -6,5 +6,5 @@ sealed class ConfigurationSaveEvent {
     object ValidateName : ConfigurationSaveEvent()
     object ShowEmptyNameDialog : ConfigurationSaveEvent()
     object DismissEmptyNameDialog : ConfigurationSaveEvent()
-
+    object DismissDuplicateNameDialog : ConfigurationSaveEvent()
 }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveScreen.kt
@@ -248,6 +248,11 @@ fun ConfigurationSaveScreen(
         message = "Nazwa kroku nie może być pusta",
         onDismiss = { onEvent(ConfigurationSaveEvent.DismissEmptyNameDialog) }
     )
+    InfoDialog(
+        show = saveState.showDuplicateNameDialog,
+        message = "Konfiguracja o takiej nazwie już istnieje.",
+        onDismiss = { onEvent(ConfigurationSaveEvent.DismissDuplicateNameDialog) }
+    )
 
 }
 
@@ -272,4 +277,3 @@ fun InfoValue(value: String) {
             .padding(vertical = 4.dp)
     )
 }
-

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveState.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveState.kt
@@ -1,7 +1,9 @@
 package com.example.friendly_words.therapist.ui.configuration.save
 
 data class ConfigurationSaveState(
-    val stepName: String = "",
+    val stepName: String = "Nowy krok",
     val showNameError: Boolean = false,
-    val showEmptyNameDialog: Boolean = false
+    val showEmptyNameDialog: Boolean = false,
+    val showDuplicateNameDialog: Boolean = false
+
 )

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveViewModel.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/save/ConfigurationSaveViewModel.kt
@@ -36,7 +36,9 @@ class ConfigurationSaveViewModel @Inject constructor() : ViewModel() {
                         state
                     }
                 }
-
+                is ConfigurationSaveEvent.DismissDuplicateNameDialog -> {
+                    state.copy(showDuplicateNameDialog = false)
+                }
                 is ConfigurationSaveEvent.ShowEmptyNameDialog -> {
                     state.copy(showEmptyNameDialog = true)
                 }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/settings/ConfigurationSettingsEvent.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/settings/ConfigurationSettingsEvent.kt
@@ -15,5 +15,7 @@ sealed class ConfigurationSettingsEvent {
     data object ShowExitDialog : ConfigurationSettingsEvent()
     data object CancelExitDialog : ConfigurationSettingsEvent()
     data object ConfirmExitDialog : ConfigurationSettingsEvent()
+    object ResetNavigation : ConfigurationSettingsEvent()
+
 
 }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/settings/ConfigurationSettingsScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/settings/ConfigurationSettingsScreen.kt
@@ -12,6 +12,7 @@ import com.example.friendly_words.therapist.ui.configuration.test.ConfigurationT
 import com.example.friendly_words.therapist.ui.configuration.learning.ConfigurationLearningScreen
 import com.example.friendly_words.therapist.ui.configuration.material.ConfigurationMaterialScreen
 import com.example.friendly_words.therapist.ui.configuration.reinforcement.ConfigurationReinforcementScreen
+import com.example.friendly_words.therapist.ui.configuration.save.ConfigurationSaveEvent
 import com.example.friendly_words.therapist.ui.configuration.save.ConfigurationSaveScreen
 import com.example.friendly_words.therapist.ui.configuration.test.ConfigurationTestEvent
 
@@ -23,6 +24,14 @@ fun ConfigurationSettingsScreen(
 ) {
     var selectedTabIndex by remember { mutableStateOf(0) }
     val state by viewModel.state.collectAsState()
+    LaunchedEffect(state.navigateToList) {
+        if (state.navigateToList) {
+            onBackClick()
+            viewModel.onEvent(ConfigurationSettingsEvent.ResetNavigation)
+        }
+    }
+
+
 
     if (state.showExitDialog) {
         YesNoDialog(
@@ -40,8 +49,9 @@ fun ConfigurationSettingsScreen(
 
     Scaffold(
         topBar = {
+            val stepName = viewModel.state.collectAsState().value.saveState.stepName
             NewConfigurationTopBar(
-                title = "Nowa konfiguracja",
+                title = "Nowy krok uczenia: ${stepName}",
                 onBackClick = {
                     viewModel.onEvent(ConfigurationSettingsEvent.ShowExitDialog)
                 }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/settings/ConfigurationSettingsState.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/settings/ConfigurationSettingsState.kt
@@ -13,6 +13,7 @@ data class ConfigurationSettingsState (
     val reinforcementState: ConfigurationReinforcementState = ConfigurationReinforcementState(),
     val testState: ConfigurationTestState = ConfigurationTestState(),
     val saveState: ConfigurationSaveState = ConfigurationSaveState(),
-    val showExitDialog: Boolean = false
+    val showExitDialog: Boolean = false,
+    val navigateToList: Boolean = false
 
 )

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/materials/creating_new/MaterialsCreatingNewMaterialEvent.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/materials/creating_new/MaterialsCreatingNewMaterialEvent.kt
@@ -21,6 +21,9 @@ sealed class MaterialsCreatingNewMaterialEvent {
     data class RequestImageDeletion(val image: Image) : MaterialsCreatingNewMaterialEvent()
     object CancelImageDeletion : MaterialsCreatingNewMaterialEvent()
     object ConfirmImageDeletion : MaterialsCreatingNewMaterialEvent()
+    object DismissDuplicateNameDialog : MaterialsCreatingNewMaterialEvent()
+    object ConfirmSaveDespiteDuplicate: MaterialsCreatingNewMaterialEvent()
+
 
 
 }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/materials/creating_new/MaterialsCreatingNewMaterialScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/materials/creating_new/MaterialsCreatingNewMaterialScreen.kt
@@ -46,6 +46,7 @@ import java.io.IOException
 import android.graphics.Bitmap
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -128,9 +129,9 @@ fun MaterialsCreatingNewMaterialScreen(
         topBar = {
             NewConfigurationTopBar(
                 title = if (state.isEditing) {
-                    if (state.resourceName.isBlank()) "Edycja materiału:" else "Edycja: ${state.resourceName}"
+                   "Edycja: ${state.resourceName}"
                 } else {
-                    if (state.resourceName.isBlank()) "Tworzenie materiału:" else "Nowy materiał: ${state.resourceName}"
+                     "Nowy materiał: ${state.resourceName}"
                 },
                 onBackClick = { viewModel.onEvent(MaterialsCreatingNewMaterialEvent.ShowExitDialog) }
             )
@@ -154,25 +155,33 @@ fun MaterialsCreatingNewMaterialScreen(
 
                     Text("Uczone słowo", fontSize = 28.sp, fontWeight = FontWeight.Bold, color = DarkBlue)
                     Spacer(modifier = Modifier.height(8.dp))
-                    TextField(
+                    OutlinedTextField(
                         value = state.learnedWord,
                         onValueChange = {
                             viewModel.onEvent(MaterialsCreatingNewMaterialEvent.LearnedWordChanged(it))
                         },
-                        placeholder = { Text("Wpisz uczone słowo...") },
-                        modifier = Modifier.fillMaxWidth(0.8f).focusRequester(focusRequester),
-                        colors = TextFieldDefaults.textFieldColors(
-                            backgroundColor = Color.White,
-                            focusedIndicatorColor = DarkBlue,
-                            unfocusedIndicatorColor = Color.Gray
-                        ),
+                        label = { Text("Wpisz uczone słowo") },
+                        modifier = Modifier
+                            .fillMaxWidth(0.8f)
+                            .focusRequester(focusRequester),
                         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
                         keyboardActions = KeyboardActions(
                             onDone = {
                                 keyboardController?.hide()
                             }
+                        ),
+                        colors = TextFieldDefaults.outlinedTextFieldColors(
+                            backgroundColor = Color.White,
+                            disabledTextColor = Color.DarkGray,
+                            disabledBorderColor = Color.Gray,
+                            focusedBorderColor = DarkBlue,
+                            unfocusedBorderColor = Color.Gray,
+                            focusedLabelColor = DarkBlue,
+                            unfocusedLabelColor = Color.DarkGray,
+                            cursorColor = Color.Black
                         )
                     )
+
 
                     Spacer(modifier = Modifier.height(16.dp))
 
@@ -205,30 +214,34 @@ fun MaterialsCreatingNewMaterialScreen(
                         color = if (state.allowEditingResourceName) DarkBlue else Color.Gray
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    TextField(
+                    OutlinedTextField(
                         value = state.resourceName,
                         onValueChange = {
                             if (state.allowEditingResourceName) {
                                 viewModel.onEvent(MaterialsCreatingNewMaterialEvent.ResourceNameChanged(it))
                             }
                         },
-                        placeholder = { Text("Wpisz nazwę...") },
+                        label = { Text("Wpisz nazwę") },
                         enabled = state.allowEditingResourceName,
                         modifier = Modifier.fillMaxWidth(0.8f),
-                        colors = TextFieldDefaults.textFieldColors(
-                            backgroundColor = Color.White,
-                            disabledTextColor = Color.DarkGray,
-                            disabledIndicatorColor = Color.Gray,
-                            focusedIndicatorColor = DarkBlue,
-                            unfocusedIndicatorColor = Color.Gray
-                        ),
                         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
                         keyboardActions = KeyboardActions(
                             onDone = {
                                 keyboardController?.hide()
                             }
+                        ),
+                        colors = TextFieldDefaults.outlinedTextFieldColors(
+                            backgroundColor = Color.White,
+                            disabledTextColor = Color.DarkGray,
+                            disabledBorderColor = Color.Gray,
+                            focusedBorderColor = DarkBlue,
+                            unfocusedBorderColor = Color.Gray,
+                            focusedLabelColor = DarkBlue,
+                            unfocusedLabelColor = Color.DarkGray,
+                            cursorColor = Color.Black
                         )
                     )
+
                     if (state.showNameConflictDialog) {
                         InfoDialog(
                             show = true,
@@ -363,6 +376,18 @@ fun MaterialsCreatingNewMaterialScreen(
                 },
                 onDismiss = {
                     viewModel.onEvent(MaterialsCreatingNewMaterialEvent.DismissExitDialog)
+                }
+            )
+        }
+        if (state.showDuplicateNameConfirmation) {
+            YesNoDialog(
+                show = true,
+                message = "Materiał o tej nazwie już istnieje. Czy chcesz mimo to zapisać?",
+                onConfirm = {
+                    viewModel.onEvent(MaterialsCreatingNewMaterialEvent.ConfirmSaveDespiteDuplicate)
+                },
+                onDismiss = {
+                    viewModel.onEvent(MaterialsCreatingNewMaterialEvent.DismissDuplicateNameDialog)
                 }
             )
         }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/materials/creating_new/MaterialsCreatingNewMaterialState.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/materials/creating_new/MaterialsCreatingNewMaterialState.kt
@@ -10,11 +10,13 @@ data class MaterialsCreatingNewMaterialState (
     val isEditing: Boolean = false,
     //val nameExists: Boolean = false,
     val showNameConflictDialog: Boolean = false,
+    val showDuplicateNameConfirmation: Boolean = false,
     val saveCompleted: Boolean = false,
     val exitWithoutSaving: Boolean = false,
     val newlySavedResourceId: Long? = null,
     val learnedWord: TextFieldValue = TextFieldValue(""),
     val allowEditingResourceName: Boolean = false,
-    val imageToConfirmDelete: Image? = null
+    val imageToConfirmDelete: Image? = null,
+    val confirmingDuplicateSave: Boolean = false
 
 )


### PR DESCRIPTION
-Materials with the same name are correctly added to the configuration 
-Displaying the learned word in the configuration
-Fixing word highlighting when adding a new word to the configuration and when deleting 
-Correcting the header when creating a new material 
-Unifying the appearance of text fields
-Dynamically entering the name of the new learning step in the top bar 
-Checking if a configuration with the same name already exists 
-Returning to the configuration list after adding a configuration