### PR TITLE
Developing new features

### DIFF
--- a/app/src/main/java/com/example/friendly_words/therapist/ui/components/NewConfigurationTopTabs.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/components/NewConfigurationTopTabs.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.unit.dp
 fun NewConfigurationTopTabs(
     selectedTabIndex: Int,
     onTabSelected: (Int) -> Unit,
-    tabTitles: List<String> = listOf("MATERIAŁ", "UCZENIE", "WZMOCNIENIA", "TEST", "ZAPISZ")
+    tabTitles: List<String> = listOf("MATERIAŁ", "UCZENIE", "WZMOCNIENIA", "TEST", "PODSUMOWANIE")
 ) {
     Column {
         Row(modifier = Modifier.height(50.dp)) {

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/learning/ConfigurationLearningScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/learning/ConfigurationLearningScreen.kt
@@ -198,7 +198,7 @@ fun ConfigurationLearningScreen(
                     modifier = Modifier
                 ) {
                     Text(
-                        text = "Czytanie polecenia",
+                        text = "Głosowe odtwarzanie polecenia",
                         fontSize = 20.sp,
                         fontWeight = FontWeight.Medium,
                         color = Color.Black
@@ -220,7 +220,7 @@ fun ConfigurationLearningScreen(
 
                 NumberSelector(
                     label = "Pokaż podpowiedź po (sekundach):",
-                    minValue = 3,
+                    minValue = 1,
                     maxValue = 9,
                     value = state.timeCount,
                     onValueChange = { onEvent(ConfigurationLearningEvent.SetTimeCount(it)) }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListEvent.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListEvent.kt
@@ -8,7 +8,6 @@ sealed class ConfigurationEvent {
     data class ConfirmDelete(val configuration: Configuration) : ConfigurationEvent()
     data class ActivateRequested(val configuration: Configuration) : ConfigurationEvent()
     data class ConfirmActivate(val configuration: Configuration) : ConfigurationEvent()
-    data class CopyRequested(val configuration: Configuration) : ConfigurationEvent()
     data class EditRequested(val configuration: Configuration) : ConfigurationEvent()
     //data class MarkShouldScrollToBottom(val scroll: Boolean) : ConfigurationEvent()
     object CreateRequested : ConfigurationEvent()
@@ -17,6 +16,8 @@ sealed class ConfigurationEvent {
     data class SetNewlyAddedId(val id: Long) : ConfigurationEvent()
     //data class ShowInfo(val message: String) : ConfigurationEvent()
     object DismissDialogs : ConfigurationEvent()
+    data class CopyRequested(val configuration: Configuration) : ConfigurationEvent()
+    data class ConfirmCopy(val configuration: Configuration) : ConfigurationEvent()
     object ScrollHandled : ConfigurationEvent()
     data class SetActiveMode(val configuration: Configuration, val mode: String) : ConfigurationEvent()
 

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListScreen.kt
@@ -8,6 +8,10 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import android.content.Intent
+import androidx.compose.ui.platform.LocalContext
+import com.example.friendly_words.child_app.main.MainActivityChild
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -53,6 +57,7 @@ fun ConfigurationsListScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         val handle = navController.currentBackStackEntry?.savedStateHandle
@@ -210,34 +215,64 @@ fun ConfigurationsListScreen(
                 modifier = Modifier
                     .fillMaxSize()
             ) {
-                TextField(
-                    value = state.searchQuery,
-                    onValueChange = { viewModel.onEvent(ConfigurationEvent.SearchChanged(it)) },
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .fillMaxHeight(0.2f)
-                        .padding(16.dp),
-                    placeholder = { Text("Wyszukaj", fontSize = calculateResponsiveFontSize(35.sp)) },
-                    leadingIcon = {
-                        Icon(Icons.Default.Search, contentDescription = "Search Icon", tint = Color.Gray)
-                    },
-                    keyboardOptions = KeyboardOptions.Default.copy(
-                        imeAction = ImeAction.Done
-                    ),
-                    keyboardActions = KeyboardActions(
-                        onDone = {
-                            keyboardController?.hide()
-                            focusManager.clearFocus()
-                        }
-                    ),
-                    colors = TextFieldDefaults.textFieldColors(
-                        backgroundColor = Color.White,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                        cursorColor = Color.Black
-                    ),
-                    shape = RoundedCornerShape(8.dp)
-                )
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                ) {
+                    OutlinedTextField(
+                        value = state.searchQuery,
+                        onValueChange = { viewModel.onEvent(ConfigurationEvent.SearchChanged(it)) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .heightIn(min = 56.dp), // żeby ładnie się wyrównało z przyciskiem
+                        placeholder = { Text("Wyszukaj", fontSize = calculateResponsiveFontSize(35.sp)) },
+                        leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search Icon", tint = Color.Gray) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                keyboardController?.hide()
+                                focusManager.clearFocus()
+                            }
+                        ),
+                        colors = TextFieldDefaults.outlinedTextFieldColors(
+                            focusedBorderColor = DarkBlue,
+                            unfocusedBorderColor = Color.Gray,
+                            cursorColor = Color.Black,
+                            focusedLabelColor = DarkBlue,
+                            unfocusedLabelColor = Color.Gray
+                        ),
+                        shape = RoundedCornerShape(10)
+                    )
+
+                    Spacer(Modifier.width(12.dp))
+
+
+                    IconButton(
+                        onClick = {
+                            val intent = Intent(context, MainActivityChild::class.java).apply {
+
+                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                            context.startActivity(intent)
+                        },
+                        modifier = Modifier
+                            .size(56.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color(0xFF0B930B).copy(alpha = 0.15f))
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = "Uruchom aplikację dziecka",
+                            tint = Color(0xFF0B930B),
+                            modifier = Modifier.size(36.dp)
+                        )
+                    }
+                }
+
+
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Spacer(modifier = Modifier.width(20.dp))

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListScreen.kt
@@ -370,7 +370,17 @@ fun ConfigurationsListScreen(
                         onDismiss = { viewModel.onEvent(ConfigurationEvent.DismissDialogs) }
                     )
                 }
-
+                state.showCopyDialogFor?.let { configToCopy ->
+                    YesNoDialogWithName(
+                        show = true,
+                        message = "Czy chcesz skopiować krok uczenia:",
+                        name = "${configToCopy.name}?",
+                        onConfirm = {
+                            viewModel.onEvent(ConfigurationEvent.ConfirmCopy(configToCopy))
+                        },
+                        onDismiss = { viewModel.onEvent(ConfigurationEvent.DismissDialogs) }
+                    )
+                }
                 state.showActivateDialogFor?.let { configToActivate ->
                     YesNoDialogWithName(
                         show = true,
@@ -404,6 +414,9 @@ fun ConfigurationItem(
         switchChecked = activeMode == "test"
     }
 
+    // 🔹 Stan dymku informacji dla przykładów
+    var showExampleInfo by remember { mutableStateOf(false) }
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -433,19 +446,59 @@ fun ConfigurationItem(
                     Spacer(modifier = Modifier.width(8.dp))
                     Column {
                         Spacer(modifier = Modifier.height(13.dp))
-                        Text(configuration.name, fontSize = 30.sp)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(configuration.name, fontSize = 30.sp)
+
+                            // 🔹 Ikona informacji dla przykładów
+                            if (configuration.isExample) {
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Box {
+                                    Icon(
+                                        imageVector = Icons.Default.Info,
+                                        contentDescription = "Informacja o przykładzie",
+                                        tint = Color.Gray,
+                                        modifier = Modifier
+                                            .size(28.dp)
+                                            .clickable { showExampleInfo = !showExampleInfo }
+                                    )
+                                    if (showExampleInfo) {
+                                        Popup(
+                                            onDismissRequest = { showExampleInfo = false }
+                                        ) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .clip(RoundedCornerShape(8.dp))
+                                                    .background(Color.White)
+                                                    .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+                                                    .padding(10.dp)
+                                            ) {
+                                                Text(
+                                                    text = "Przykładowy krok uczenia jest niedotykalny.\n W celu zobaczenia co jest w środku, zrób kopię przyciskiem obok.",
+                                                    fontSize = 20.sp
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         Spacer(modifier = Modifier.height(3.dp))
                         Text(
-                            if (isActive) "(aktywny krok w trybie: $activeMode)"
-                            else "(krok nieaktywny)",
+                            if (isActive) "(aktywny krok w trybie: $activeMode)" else "(krok nieaktywny)",
                             fontSize = 20.sp
                         )
                     }
                 }
             }
 
-            Column(modifier = Modifier.weight(1.25f), horizontalAlignment = Alignment.CenterHorizontally) {
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Center) {
+            Column(
+                modifier = Modifier.weight(1.25f),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
                     Text("Uczenie", fontSize = 18.sp)
                     Switch(
                         checked = switchChecked,

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListState.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListState.kt
@@ -8,6 +8,7 @@ data class ConfigurationState(
     val activeConfiguration: Configuration? = null,
     val showDeleteDialogFor: Configuration? = null,
     val showActivateDialogFor: Configuration? = null,
+    val showCopyDialogFor: Configuration? = null,
     val shouldScrollToBottom: Boolean=false,
     val infoMessage: String? = null,
     val newlyAddedConfigId: Long? = null,

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListViewModel.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/list/ConfigurationsListViewModel.kt
@@ -96,8 +96,10 @@ class ConfigurationViewModel @Inject constructor(
             is ConfigurationEvent.ClearInfoMessage -> {
                 _state.update { it.copy(infoMessage = null) }
             }
-
             is ConfigurationEvent.CopyRequested -> {
+                _state.update { it.copy(showCopyDialogFor = event.configuration) }
+            }
+            is ConfigurationEvent.ConfirmCopy -> {
 
                 val originalConfiguration = event.configuration
                 val newName = generateCopyName(event.configuration.name, _state.value.configurations.map { it.name })
@@ -140,6 +142,9 @@ class ConfigurationViewModel @Inject constructor(
                         }
                     configurationRepository.insertImageUsages(imageUsages)
                     }
+                _state.update {
+                    it.copy(showCopyDialogFor = null)
+                }
             }
 
             is ConfigurationEvent.EditRequested -> {
@@ -165,7 +170,7 @@ class ConfigurationViewModel @Inject constructor(
             }
 
             ConfigurationEvent.DismissDialogs -> _state.update {
-                it.copy(showDeleteDialogFor = null, showActivateDialogFor = null)
+                it.copy(showDeleteDialogFor = null, showActivateDialogFor = null, showCopyDialogFor = null)
             }
         }
     }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/material/ConfigurationMaterialScreen.kt
@@ -102,7 +102,7 @@ fun ImageSelectionWithCheckbox(
                         ) {
                             Checkbox(
                                 checked = inLearningStates[index],
-                                enabled = selectedImages[index],
+                                //enabled = selectedImages[index],
                                 onCheckedChange = { newLearning ->
                                     val currentTest = inTestStates[index]
                                     val shouldSelectImage = newLearning || currentTest
@@ -124,7 +124,7 @@ fun ImageSelectionWithCheckbox(
                             Spacer(modifier = Modifier.width(35.dp))
                             Checkbox(
                                 checked = inTestStates[index],
-                                enabled = selectedImages[index],
+                                //enabled = selectedImages[index],
                                 onCheckedChange = { newTest ->
                                     val currentLearning = inLearningStates[index]
                                     val shouldSelectImage = newTest || currentLearning
@@ -486,7 +486,7 @@ fun ConfigurationMaterialScreen(
                                     if (filteredWords.isEmpty()) {
                                         item {
                                             Text(
-                                                "BRAK WYNIKÓW",
+                                                "BRAK WYNIKÓW\nDODAJ MATERIAŁY W SEKCJI MATERIAŁY EDUKACYJNE",
                                                 fontSize = 16.sp,
                                                 color = Color.Gray,
                                                 modifier = Modifier.padding(vertical = 8.dp)

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/reinforcement/ConfigurationReinforcementScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/configuration/reinforcement/ConfigurationReinforcementScreen.kt
@@ -45,7 +45,7 @@ fun ConfigurationReinforcementScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Pochwały słowne",
+                    text = "Wzmocnienia słowne",
                     fontSize = 28.sp,
                     fontWeight = FontWeight.Bold,
                     color = DarkBlue,
@@ -129,7 +129,7 @@ fun ConfigurationReinforcementScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Pochwały wizualne",
+                    text = "Wzmocnienia wizualne",
                     fontSize = 28.sp,
                     fontWeight = FontWeight.Bold,
                     color = DarkBlue,

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/main/MainActivity.kt
@@ -32,7 +32,7 @@ import java.lang.Math.sqrt
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
         setContent {
             MaterialTheme {
                 ScreenNavigation()

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/main/MainScreen.kt
@@ -2,6 +2,8 @@ package com.example.friendly_words.therapist.ui.main
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -142,6 +144,9 @@ fun MainContent(
     onConfigClick: () -> Unit,
     onMaterialsClick: () -> Unit
 ) {
+    var showInfo by remember { mutableStateOf(false) }
+    var showMaterialsInfo by remember { mutableStateOf(false) }
+    var showConfigInfo by remember { mutableStateOf(false) }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -154,15 +159,24 @@ fun MainContent(
                         Text(
                             "Przyjazne Słowa Ustawienia",
                             fontSize = 30.sp,
-                            modifier = Modifier.weight(1f),
                             color = Color.White
                         )
+                            IconButton(onClick = { showInfo = true }) {
+                                Icon(
+                                    imageVector = Icons.Default.Info,
+                                    contentDescription = "Informacje",
+                                    tint = Color.White,
+                                    modifier = Modifier.size(32.dp)
+                                )
+                            }
+
                     }
                 },
                 backgroundColor = DarkBlue
+
             )
         }
-    ) { padding ->
+    )  { padding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -192,7 +206,26 @@ fun MainContent(
                         .width((LocalConfiguration.current.screenWidthDp * 0.7f).dp)
                         .height(85.dp)
                 ) {
-                    Text("MATERIAŁY EDUKACYJNE", fontSize = 25.sp)
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+
+                        Text("MATERIAŁY EDUKACYJNE", fontSize = 25.sp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        IconButton(
+                            onClick = { showMaterialsInfo = true },
+                            modifier = Modifier.size(40.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Info,
+                                contentDescription = "Informacje o materiałach edukacyjnych",
+                                tint = DarkBlue,
+                                modifier = Modifier.size(32.dp)
+                            )
+                        }
+
+                    }
                 }
 
                 Button(
@@ -206,8 +239,61 @@ fun MainContent(
                         .height(85.dp)
                 ) {
                     Text("KROKI UCZENIA", fontSize = 25.sp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    IconButton(
+                        onClick = { showConfigInfo = true },
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Info,
+                            contentDescription = "Informacje o krokach uczenia",
+                            tint = DarkBlue,
+                            modifier = Modifier.size(32.dp)
+                        )
+                    }
                 }
             }
         }
     }
+    if (showMaterialsInfo) {
+        AlertDialog(
+            onDismissRequest = { showMaterialsInfo = false },
+            title = { Text("Materiały edukacyjne") },
+            text = { Text("Tekst do wklejenia od Pani z Insytutu.") },
+            confirmButton = {
+                TextButton(onClick = { showMaterialsInfo = false }) {
+                    Text("OK", color = DarkBlue)
+                }
+            }
+        )
+    }
+    if (showConfigInfo) {
+        AlertDialog(
+            onDismissRequest = { showConfigInfo = false },
+            title = { Text("Kroki uczenia") },
+            text = { Text("Tekst do wklejenia od Pani z Insytutu.") },
+            confirmButton = {
+                TextButton(onClick = { showConfigInfo = false }) {
+                    Text("OK", color = DarkBlue)
+                }
+            }
+        )
+    }
+    if (showInfo) {
+        AlertDialog(
+            onDismissRequest = { showInfo = false },
+            title = { Text("Na czym polega aplikacja?") },
+            text = {
+                Text(
+                    "Tekst przygotowany przez Insytut."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showInfo = false }) {
+                    Text("OK",color= DarkBlue)
+                }
+            }
+        )
+    }
+
 }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/main/MainScreen.kt
@@ -50,6 +50,7 @@ fun MainScreen() {
         navController = navController,
         startDestination = NavRoutes.MAIN
     ) {
+
         composable(NavRoutes.MAIN) {
             MainContent(
                 onConfigClick = { navController.navigate(NavRoutes.CONFIG_LIST) },
@@ -196,37 +197,38 @@ fun MainContent(
                     fontSize = 25.sp
                 )
 
-                Button(
-                    onClick = onMaterialsClick,
-                    colors = ButtonDefaults.buttonColors(
-                        backgroundColor = LightBlue2,
-                        contentColor = Color.Black
-                    ),
-                    modifier = Modifier
-                        .width((LocalConfiguration.current.screenWidthDp * 0.7f).dp)
-                        .height(85.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
+                    Button(
+                        onClick = onMaterialsClick,
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = LightBlue2,
+                            contentColor = Color.Black
+                        ),
+                        modifier = Modifier
+                            .width((LocalConfiguration.current.screenWidthDp * 0.7f).dp)
+                            .height(85.dp)
                     ) {
-
-                        Text("MATERIAŁY EDUKACYJNE", fontSize = 25.sp)
-                        Spacer(modifier = Modifier.width(8.dp))
-                        IconButton(
-                            onClick = { showMaterialsInfo = true },
-                            modifier = Modifier.size(40.dp)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
                         ) {
-                            Icon(
-                                imageVector = Icons.Default.Info,
-                                contentDescription = "Informacje o materiałach edukacyjnych",
-                                tint = DarkBlue,
-                                modifier = Modifier.size(32.dp)
-                            )
-                        }
 
+                            Text("MATERIAŁY EDUKACYJNE", fontSize = 25.sp)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            IconButton(
+                                onClick = { showMaterialsInfo = true },
+                                modifier = Modifier.size(40.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Info,
+                                    contentDescription = "Informacje o materiałach edukacyjnych",
+                                    tint = DarkBlue,
+                                    modifier = Modifier.size(32.dp)
+                                )
+                            }
+                        }
                     }
-                }
+
+
 
                 Button(
                     onClick = onConfigClick,
@@ -251,7 +253,9 @@ fun MainContent(
                             modifier = Modifier.size(32.dp)
                         )
                     }
+
                 }
+
             }
         }
     }

--- a/app/src/main/java/com/example/friendly_words/therapist/ui/materials/list/MaterialsListScreen.kt
+++ b/app/src/main/java/com/example/friendly_words/therapist/ui/materials/list/MaterialsListScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.platform.LocalFocusManager
@@ -52,6 +53,8 @@ fun MaterialsListScreen(
     viewModel: MaterialsListViewModel = hiltViewModel()
 ) {
     val state by viewModel.uiState.collectAsState()
+    var expandedImagePath by remember { mutableStateOf<String?>(null) }
+
 
     val snackbarHostState = remember { SnackbarHostState() }
     val focusManager = LocalFocusManager.current
@@ -196,7 +199,8 @@ fun MaterialsListScreen(
                         focusedLabelColor = DarkBlue,
                         unfocusedLabelColor = Color.Gray,
                         cursorColor = Color.Black
-                    )
+                    ),
+                    shape = RoundedCornerShape(10)
                 )
 
                 Row(
@@ -354,6 +358,7 @@ fun MaterialsListScreen(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .aspectRatio(1f)
+                                        .clickable { expandedImagePath = image.path }
                                 )
                             }
                         }
@@ -364,6 +369,33 @@ fun MaterialsListScreen(
             }
         }
     }
+    if (expandedImagePath != null) {
+        // Opcjonalnie: obsługa wstecz, by zamykać overlay przy Back
+        androidx.activity.compose.BackHandler(enabled = true) {
+            expandedImagePath = null
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.95f))
+                .clickable { expandedImagePath = null }, // <- tap anywhere to close
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                painter = rememberAsyncImagePainter(expandedImagePath),
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight()
+                    .padding(16.dp)
+                    .clickable { expandedImagePath = null }, // <- tap image to close
+                alignment = Alignment.Center,
+                contentScale = androidx.compose.ui.layout.ContentScale.Fit
+            )
+        }
+    }
+
 
     // Dialog potwierdzający usunięcie
     val materialToDelete = state.materialToDelete


### PR DESCRIPTION
UI text changes

 Replace: “Save” → “Summary”.

 Rename: “Read instruction” → “Voice playback of instruction”.

 Rename: “Visual praise” → “Visual reinforcement”.

 Rename: “Verbal praise” → “Verbal reinforcement”.

Tooltips & help

 Add an (i) icon on example configurations stating they’re read-only and you must make a copy to see what’s inside.

 Start screen: added (i) in place of the “what the app does” text.

 Start screen: added (i) for “educational materials” and for “learning steps”.

 Emailed the institute asking for exact tooltip copy for:

what the app is about,

what educational materials are and why they’re used,

what learning steps are and why they’re used.

Settings & controls

 Add setting: “Show hint after (seconds)”.

 Add Response time setting.

 When adding materials to a learning step and you see NO RESULTS (0 materials or filtered out), show guidance on how to add materials.

 Configuration screen: outline the search box so it doesn’t visually blend with the background.

Materials & configurations UX

 In new configuration, allow selecting/deselecting materials directly from item buttons (no need for the top master toggle).

 Materials list: tapping an image opens a full-screen preview; tapping again closes it.

 In the “add image to material” view, show a helper note in the empty square: “If you want to add a photo, use the buttons below.”

Cross-app navigation

 Add a PLAY button next to the search field that launches the child app.